### PR TITLE
Bump struts2.version from 2.3.30 to 2.5.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <name>dvja</name>
 
     <properties>
-        <struts2.version>2.3.30</struts2.version>
+        <struts2.version>2.5.22</struts2.version>
         <log4j2.version>2.3</log4j2.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>3.0.5.RELEASE</spring.version>


### PR DESCRIPTION
Bumps `struts2.version` from 2.3.30 to 2.5.22.

Updates `struts2-core` from 2.3.30 to 2.5.22
- [Release notes](https://github.com/apache/struts/releases)
- [Commits](https://github.com/apache/struts/commits)

Updates `struts2-config-browser-plugin` from 2.3.30 to 2.5.22

Updates `struts2-junit-plugin` from 2.3.30 to 2.5.22

Updates `struts2-spring-plugin` from 2.3.30 to 2.5.22

Signed-off-by: dependabot[bot] <support@github.com>